### PR TITLE
Add to and from pem

### DIFF
--- a/src/lcrypto.c
+++ b/src/lcrypto.c
@@ -11,6 +11,7 @@
 #include <openssl/rsa.h>
 #include <openssl/dsa.h>
 #include <openssl/pem.h>
+#include <openssl/bio.h>
 #include <stddef.h>
 
 
@@ -992,6 +993,28 @@ static int pkey_generate(lua_State *L)
   }
 }
 
+static int pkey_to_pem(lua_State *L)
+{
+  EVP_PKEY **pkey = (EVP_PKEY **)luaL_checkudata(L, 1, LUACRYPTO_PKEYNAME);
+  int private = lua_isboolean(L, 2) && lua_toboolean(L, 2);
+
+  long len;
+  BUF_MEM *buf;
+  BIO *mem = BIO_new(BIO_s_mem());
+
+  if(private)
+    PEM_write_bio_PrivateKey(mem, *pkey, NULL, NULL, 0, NULL, NULL);
+  else
+    PEM_write_bio_PUBKEY(mem, *pkey);
+
+  len = BIO_get_mem_ptr(mem, &buf);
+
+  lua_pushlstring(L, buf->data, buf->length);
+  BIO_free(mem);
+
+  return 1;
+}
+
 static int pkey_read(lua_State *L)
 {
   const char *filename = luaL_checkstring(L, 1);
@@ -1002,11 +1025,10 @@ static int pkey_read(lua_State *L)
   if (!fp)
     luaL_error(L, "File not found: %s", filename);
 
-  if (readPrivate) {
+  if (readPrivate)
     *pkey = PEM_read_PrivateKey(fp, NULL, NULL, NULL);
-  } else {
+  else
     *pkey = PEM_read_PUBKEY(fp, NULL, NULL, NULL);
-  }
 
   fclose(fp);
 
@@ -1014,6 +1036,33 @@ static int pkey_read(lua_State *L)
     return crypto_error(L);
 
   return 1;
+}
+
+static int pkey_from_pem(lua_State *L)
+{
+  const char *key = luaL_checkstring(L, 1);
+  int private = lua_isboolean(L, 2) && lua_toboolean(L, 2);
+  EVP_PKEY **pkey = pkey_new(L);
+  BIO *mem = BIO_new(BIO_s_mem());
+  int ret;
+
+  ret = BIO_puts(mem, key);
+  if (ret != strlen(key))
+    goto error;
+
+  if(private)
+    *pkey = PEM_read_bio_PrivateKey(mem, NULL, NULL, NULL);
+  else
+    *pkey = PEM_read_bio_PUBKEY(mem, NULL, NULL, NULL);
+
+  if (! *pkey)
+    goto error;
+
+  return 1;
+
+error:
+  BIO_free(mem);
+  return crypto_error(L);
 }
 
 static int pkey_write(lua_State *L)
@@ -1546,12 +1595,14 @@ static void create_metatables (lua_State *L)
   struct luaL_reg pkey_functions[] = {
     { "generate", pkey_generate },
     { "read", pkey_read },
+    { "from_pem", pkey_from_pem },
     { NULL, NULL }
   };
   struct luaL_reg pkey_methods[] = {
     { "__tostring", pkey_tostring },
     { "__gc", pkey_gc },
     { "write", pkey_write },
+    { "to_pem", pkey_to_pem},
     { NULL, NULL }
   };
 

--- a/src/lcrypto.h
+++ b/src/lcrypto.h
@@ -30,5 +30,4 @@ LUACRYPTO_API void luacrypto_setmeta (lua_State *L, const char *name);
 LUACRYPTO_API void luacrypto_set_info (lua_State *L);
 LUACRYPTO_API int luaopen_crypto(lua_State *L);
 
-
 #endif

--- a/src/lcrypto.h
+++ b/src/lcrypto.h
@@ -28,6 +28,7 @@
 LUACRYPTO_API int luacrypto_createmeta (lua_State *L, const char *name, const luaL_reg *methods);
 LUACRYPTO_API void luacrypto_setmeta (lua_State *L, const char *name);
 LUACRYPTO_API void luacrypto_set_info (lua_State *L);
+LUACRYPTO_API int luaopen_crypto(lua_State *L);
 
 
 #endif

--- a/tests/pkeytest.lua
+++ b/tests/pkeytest.lua
@@ -2,6 +2,57 @@ require 'crypto'
 
 assert(crypto.pkey, "crypto.pkey is unavaliable")
 
+local RSA_PUBLIC_KEY = [[
+-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDAIy7sjJXo3ePWF1PZ81DelW1E
+4VphWD+VPBzT8oCYY9dViJ4lszW/t5LX0IYAm+veuJyF5ffkAeeOWvI7vCg+5s3b
+l9QqXgU8izuiXD0W6Wfm0YUU9VLGiFWnyTHpvZwqhnqmSEFCqPh+bWshCn/J5pZa
+g8GOfgG42UgCrxnNWwIDAQAB
+-----END PUBLIC KEY-----
+]]
+
+local RSA_PRIV_KEY = [[
+-----BEGIN RSA PRIVATE KEY-----
+MIICWwIBAAKBgQDAIy7sjJXo3ePWF1PZ81DelW1E4VphWD+VPBzT8oCYY9dViJ4l
+szW/t5LX0IYAm+veuJyF5ffkAeeOWvI7vCg+5s3bl9QqXgU8izuiXD0W6Wfm0YUU
+9VLGiFWnyTHpvZwqhnqmSEFCqPh+bWshCn/J5pZag8GOfgG42UgCrxnNWwIDAQAB
+AoGAa2R++trNg75adbTOOnlEj1ToIWLwWI6x42EZH+JgvEy59GYLNzlG5qTd3+D+
+tWJxYSjA3BqhBwGFgs0UrgzKVPwKbj1nbX0w91PmfdyGEutN84xRtZWkdMBiFacV
+Hy8Y0rvw/xmlf39xkv1n8whtb7sKxZjxRwVWpSU2i5ovQ5kCQQD98agvwLRoJQ3e
+AkuIpSNHfk9lRkr2A0ZHJjRRYOWN+xl/bShxMKCSrlzHqmIEd8wIkgXkWFSCDO4M
+WcE3G2y3AkEAwbFr6SFQHqh48hO8Lq040S8y+wVZrH7DIwYM3Ckc7JnurFQP9B6U
+2BOPsLuCNoWeMJOwyJiIXwd4KT7XvzAIfQJAbNAJ0zxtkVqfUIwHNawdK9tRxgGS
+yUup537VWDF+65G24UUy2R2PEIsqMlwt1+BFSz7Wy3uV6owDzMMA6c4UjQJAJC/V
+jVSf91paXj+5pK7QMqSyzZsOSd/U7TIwLOGxebK4mJGL+XvNKyFccxRVG4KTL1go
+axG0SKzIkkwfWqTKsQJAf58QgbmGIwDwQgk2StWuulY9HhGpd73JySPyTKR2Lmpe
+wDJiqtOCnY3hEss2co97U/vzL+Cic4hXT3gGAQiDwQ==
+-----END RSA PRIVATE KEY-----
+]]
+
+function test_verify(kpub, kpriv)
+  assert(crypto.sign, "crypto.sign is unavaliable")
+  assert(crypto.verify, "crypto.verify is unavaliable")
+
+  message = 'This message will be signed'
+
+  sig = assert(crypto.sign('md5', message, kpriv))
+  verified = crypto.verify('md5', message, sig, kpub)
+  assert(verified, "message not verified")
+
+  nverified = crypto.verify('md5', message..'x', sig, kpub)
+  assert(not nverified, "message verified, when it shouldn't be")
+
+  print("OK")
+end
+
+kpub = assert(crypto.pkey.from_pem(RSA_PUBLIC_KEY))
+kpriv = assert(crypto.pkey.from_pem(RSA_PRIV_KEY, true))
+
+assert(kpub:to_pem() == RSA_PUBLIC_KEY)
+assert(kpriv:to_pem(true) == RSA_PRIV_KEY)
+
+test_verify(kpub, kpriv)
+
 k = crypto.pkey.generate('rsa', 1024)
 assert(k, "no key generated")
 
@@ -10,16 +61,4 @@ k:write('pub.pem', 'priv.pem')
 kpub = assert(crypto.pkey.read('pub.pem'))
 kpriv = assert(crypto.pkey.read('priv.pem', true))
 
-assert(crypto.sign, "crypto.sign is unavaliable")
-assert(crypto.verify, "crypto.verify is unavaliable")
-
-message = 'This message will be signed'
-
-sig = assert(crypto.sign('md5', message, kpriv))
-verified = crypto.verify('md5', message, sig, kpub)
-assert(verified, "message not verified")
-
-nverified = crypto.verify('md5', message..'x', sig, kpub)
-assert(not nverified, "message verified, when it shouldn't be")
-
-print("OK")
+test_verify(kpub, kpriv)


### PR DESCRIPTION
Hi-

We are doing a lot of work on luacrypto in racker/virgo. Here is the first set of patches.

Thanks, Brandon

```
luacrypto: add to/from pem to pkey

Add functions/methods to make it easy to read keys from a lua string
buffer.

lcrypto.h: remove ^M from all of the lines

Make this file purely unix line endings

lcrypto.h: define luaopen_crypto

define luaopen_crypto for use in custom lua environments.
```
