### PR TITLE
x509_cert: add x509_cert to read out pubkey

### DIFF
--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -102,6 +102,8 @@
     <dt><strong>pad</strong></dt>
     <dd>An optional <b>boolean</b> flag whether padding should be used. The default is true, which means that input of any size can be provided. Returned date may be larger than input string due to the padding. If explicitly set to <b>false</b>, the padding is turned off and the input data size has to be multiple of block length.</dd>
     </dd>
+    <dt><strong>pem</strong></dt>
+    <dd>A <b>string</b> containing a PEM formatted certificate.</dd>
 </dl>
 
 <h3>Error handling</h3>
@@ -265,7 +267,28 @@ The functions throw an error when known invalid parameters are passed, such as n
     <dd>Generates the HMAC for the loaded data, optionally appending on new data provided by <code>string</code> prior to hashing. The optional <code>raw</code> flag, defaulted to false, is a boolean indicating whether the output should be a direct binary equivalent of the message digest or formatted as a hexadecimal string (the default). Note that you can only run this method once on an object; running it a second time will product a bogus HMAC because the internal state is irrecoverably destroyed after the first call.</dd>
 </dl>
 
+<h3>X509 Certificate - crypto.x509_cert</h3>
+<dl>
+    <dt><strong>crypto.x509_cert()</strong></dt>
+    <dd>Return an empty x509 certificate object.</dd>
 
+    <dt><strong>x509_cert:pubkey()</strong></dt>
+    <dd>Get a <code>crypto.pkey</code> object that represents the raw key of the <code>x509_cert</code>.</dd>
+
+</dl>
+
+<h3>X509 Certificate Authority - crypto.x509_ca</h3>
+<dl>
+    <dt><strong>crypto.x509()</strong></dt>
+    <dd>Return an empty x509 certificate authority.</dd>
+
+    <dt><strong>x509_ca:add_pem(pem)</strong></dt>
+    <dd>Add a x509 CA certificate as a trusted cert.</dd>
+
+    <dt><strong>x509_ca:verify_pem(pem)</strong></dt>
+    <dd>Verify that the pem is signed by one of the x509 CA's added via <code>x509_ca:add_pem</code></dd>
+
+</dl>
 
 <h3>Misc functions - crypto</h3>
 <dl>

--- a/src/lcrypto.h
+++ b/src/lcrypto.h
@@ -24,6 +24,7 @@
 #define LUACRYPTO_HMACNAME    "crypto.hmac"
 #define LUACRYPTO_RANDNAME    "crypto.rand"
 #define LUACRYPTO_PKEYNAME    "crypto.pkey"
+#define LUACRYPTO_X509_CERT_NAME "crypto.x509"
 #define LUACRYPTO_X509_CA_NAME "crypto.x509_ca"
 
 LUACRYPTO_API int luacrypto_createmeta (lua_State *L, const char *name, const luaL_reg *methods);


### PR DESCRIPTION
With this patch we can now do things like verify a x509 cert against a x509_ca
then extract its pubkey and test a message signature.

```
cert = crypto.x509_cert()
cert:from_pem(server_cert)
kpub = cert:pubkey()
message = 'Hello world'
verified = crypto.verify('md5', message, signature, kpub)
```
