### PR TITLE
src: lcrypto: fix compiler warning

### DIFF
--- a/src/lcrypto.c
+++ b/src/lcrypto.c
@@ -1058,7 +1058,7 @@ static int pkey_from_pem(lua_State *L)
   int private = lua_isboolean(L, 2) && lua_toboolean(L, 2);
   EVP_PKEY **pkey = pkey_new(L);
   BIO *mem = BIO_new(BIO_s_mem());
-  int ret;
+  size_t ret;
 
   ret = BIO_puts(mem, key);
   if (ret != strlen(key)) {


### PR DESCRIPTION
../deps/luacrypto/src/lcrypto.c:1064:11: warning: comparison of integers of different signs: 'int'
      and 'size_t' (aka 'unsigned long') [-Wsign-compare]
  if (ret != strlen(key)) {
      ~~~ ^  ~~~~~~~~~~~
1 warning generated.
