### PR TITLE
Fix. rockspecs work on windwos MSVC/MinGW

### DIFF
--- a/rockspecs/luacrypto-0.3.2-1.rockspec
+++ b/rockspecs/luacrypto-0.3.2-1.rockspec
@@ -1,0 +1,39 @@
+package = "LuaCrypto"
+version = "0.3.2-1"
+description = {
+	summary = "A Lua frontend to OpenSSL",
+	detailed = [[LuaCrypto is a Lua frontend to the OpenSSL cryptographic library. The OpenSSL features that are currently exposed are: 
+digests (MD5, SHA-1, HMAC, and more), encryption, decryption and crypto-grade random number generators.]],
+	homepage = "http://mkottman.github.com/luacrypto/",
+	license = "MIT",
+}
+dependencies = {
+	"lua >= 5.1, < 5.3",
+}
+external_dependencies = {
+	OPENSSL = {
+		header = "openssl/evp.h"
+	}
+}
+source = {
+	url = "https://github.com/mkottman/luacrypto/archive/0.3.2.zip",
+	dir = "luacrypto-0.3.2",
+}
+build = {
+	type = "builtin",
+	modules = {
+		crypto = {
+			sources = "src/lcrypto.c",
+			incdirs = "$(OPENSSL_INCDIR)",
+			libdirs = "$(OPENSSL_LIBDIR)",
+			libraries = "crypto",
+		}
+	},
+	platforms = {
+		windows = {
+			modules = { crypto = { libraries = {'libeay32', 'ssleay32', 'kernel32', 'user32', 'gdi32', 'advapi32'} } }
+		}
+	},
+	copy_directories = { "doc" }
+}
+build.platforms.mingw32 = build.platforms.windows

--- a/rockspecs/luacrypto-git-1.rockspec
+++ b/rockspecs/luacrypto-git-1.rockspec
@@ -8,28 +8,32 @@ digests (MD5, SHA-1, HMAC, and more), encryption, decryption and crypto-grade ra
 	license = "MIT",
 }
 dependencies = {
-	"lua >= 5.1",
+	"lua >= 5.1, < 5.3",
+}
+external_dependencies = {
+	OPENSSL = {
+		header = "openssl/evp.h"
+	}
 }
 source = {
-	url = [[git://github.com/mkottman/luacrypto.git]],
-	dir = "luacrypto"
+	url = "https://github.com/mkottman/luacrypto/archive/master.zip",
+	dir = "luacrypto-master",
 }
 build = {
+	type = "builtin",
+	modules = {
+		crypto = {
+			sources = "src/lcrypto.c",
+			incdirs = "$(OPENSSL_INCDIR)",
+			libdirs = "$(OPENSSL_LIBDIR)",
+			libraries = "crypto",
+		}
+	},
 	platforms = {
 		windows = {
-			type = "command",
-			build_command = [[vcbuild ./luacrypto.vcproj Release /useenv /rebuild]],
-			install_command = [[copy ".\Release\crypto.dll" "$(LIBDIR)\crypto.dll" /y ]]
-		},
-		unix = {
-			type = "make",
-			variables = {
-				INCONCERT_DEVEL = "$(INCONCERT_DEVEL)",
-				LUA_LUADIR = "$(LUADIR)",
-				LUA_LIBDIR = "$(LIBDIR)",
-				LUA_PREFIX  = "$(PREFIX)"
-			}
+			modules = { crypto = { libraries = {'libeay32', 'ssleay32', 'kernel32', 'user32', 'gdi32', 'advapi32'} } }
 		}
 	},
 	copy_directories = { "doc" }
 }
+build.platforms.mingw32 = build.platforms.windows


### PR DESCRIPTION
This rockspec file do not use make.
If you think that make better you can update only windows platform.
